### PR TITLE
Adding ability to send sms

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,24 +35,21 @@ class _MyAppState extends State<MyApp> {
     await Vibration.vibrate(duration: 5000, repeat: 2);
   }
 
+  onSendStatus(SendStatus status) {
+    setState(() {
+      _message = status == SendStatus.SENT ? "sent" : "delivered";
+    });
+  }
+
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlatformState() async {
     // Platform messages may fail, so we use a try/catch PlatformException.
     var sms = FlutterSms.instance;
 
-    var messages = await sms.getInboxSms(
-        columns: [
-          SmsColumn.DATE,
-          SmsColumn.ADDRESS,
-          SmsColumn.BODY,
-          SmsColumn.READ
-        ],
-        filter: SmsFilter.where(SmsColumn.DATE)
-            .greaterThanOrEqualTo("1593865041625")
-            .and(SmsColumn.READ)
-            .equals("0"),
-        sortOrder: [OrderBy(SmsColumn.BODY, sort: Sort.ASC), OrderBy(SmsColumn.DATE, sort: Sort.ASC),]);
-    messages;
+    sms.sendSmsByDefaultApp(
+        to: "+919004640268",
+        message: "Sent from flutter",
+    );
     // If the widget was removed from the tree while the asynchronous platform
     // message was in flight, we want to discard the reply rather than calling
     // setState to update our non-existent appearance.

--- a/lib/flutter_sms.dart
+++ b/lib/flutter_sms.dart
@@ -42,6 +42,9 @@ class FlutterSms {
 
   MessageHandler _onNewMessages;
   MessageHandler _onBackgroundMessages;
+  SmsSendStatusListener _statusListener;
+
+  FlutterSms(this._foregroundChannel, this._platform);
 
   static FlutterSms get instance => _instance;
 
@@ -99,6 +102,13 @@ class FlutterSms {
     switch (call.method) {
       case "onMessage":
         return _onNewMessages(call.arguments.cast<String, dynamic>());
+        break;
+      case "smsSent":
+        return _statusListener(SendStatus.SENT);
+        break;
+      case "smsDelivered":
+        return _statusListener(SendStatus.DELIVERED);
+        break;
     }
   }
 
@@ -167,7 +177,11 @@ class FlutterSms {
     SmsSendStatusListener statusListener,
     bool isMultipart = false,
   }) {
-    bool listenStatus = statusListener != null ? true : false;
+    bool listenStatus = false;
+    if (statusListener != null) {
+      _statusListener = statusListener;
+      listenStatus = true;
+    }
     final Map<String, dynamic> args = {
       "address": to,
       "message_body": message,


### PR DESCRIPTION
TODO:
- [x] Send sms
- [x] Send sms via default app
- [x] List to sms send status

Add the ability to listen to sms sent and delivered events.

- Functionality implemented in Android
- Combine sending an sms and listening to events on flutter side.
1. Start listening (init broadcast receiver)
2. Send sms
3. ~~Return the stream from flutter to listen to events~~
4. Listen on foreground channel for events