### PR TITLE
Fix type cast for getSms methods. Changed to List? internally.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.2
+* Change invokeMethod call type for getSms methods to List? (No change to telephony API)
+
 ## 0.1.1
 * Added background instance for executing telephony methods in background.
 * Fix type cast issues.

--- a/lib/telephony.dart
+++ b/lib/telephony.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 import 'dart:ui';
 
 import 'package:flutter/services.dart';
@@ -174,8 +173,8 @@ class Telephony {
     assert(_platform.isAndroid == true, "Can only be called on Android.");
     final args = _getArguments(columns, filter, sortOrder);
 
-    final messages = await _foregroundChannel.invokeMethod<List?>(
-        GET_ALL_INBOX_SMS, args);
+    final messages =
+        await _foregroundChannel.invokeMethod<List?>(GET_ALL_INBOX_SMS, args);
 
     return messages
             ?.map((message) => SmsMessage.fromMap(message, columns))
@@ -204,8 +203,8 @@ class Telephony {
     assert(_platform.isAndroid == true, "Can only be called on Android.");
     final args = _getArguments(columns, filter, sortOrder);
 
-    final messages = await _foregroundChannel.invokeMethod<List?>(
-        GET_ALL_SENT_SMS, args);
+    final messages =
+        await _foregroundChannel.invokeMethod<List?>(GET_ALL_SENT_SMS, args);
 
     return messages
             ?.map((message) => SmsMessage.fromMap(message, columns))
@@ -234,8 +233,8 @@ class Telephony {
     assert(_platform.isAndroid == true, "Can only be called on Android.");
     final args = _getArguments(columns, filter, sortOrder);
 
-    final messages = await _foregroundChannel.invokeMethod<List?>(
-        GET_ALL_DRAFT_SMS, args);
+    final messages =
+        await _foregroundChannel.invokeMethod<List?>(GET_ALL_DRAFT_SMS, args);
 
     return messages
             ?.map((message) => SmsMessage.fromMap(message, columns))
@@ -261,8 +260,8 @@ class Telephony {
     assert(_platform.isAndroid == true, "Can only be called on Android.");
     final args = _getArguments(DEFAULT_CONVERSATION_COLUMNS, filter, sortOrder);
 
-    final conversations = await _foregroundChannel
-        .invokeMethod<List?>(GET_ALL_CONVERSATIONS, args);
+    final conversations = await _foregroundChannel.invokeMethod<List?>(
+        GET_ALL_CONVERSATIONS, args);
 
     return conversations
             ?.map((conversation) => SmsConversation.fromMap(conversation))

--- a/lib/telephony.dart
+++ b/lib/telephony.dart
@@ -174,7 +174,7 @@ class Telephony {
     assert(_platform.isAndroid == true, "Can only be called on Android.");
     final args = _getArguments(columns, filter, sortOrder);
 
-    final messages = await _foregroundChannel.invokeMethod<List<LinkedHashMap>>(
+    final messages = await _foregroundChannel.invokeMethod<List?>(
         GET_ALL_INBOX_SMS, args);
 
     return messages
@@ -204,7 +204,7 @@ class Telephony {
     assert(_platform.isAndroid == true, "Can only be called on Android.");
     final args = _getArguments(columns, filter, sortOrder);
 
-    final messages = await _foregroundChannel.invokeMethod<List<LinkedHashMap>>(
+    final messages = await _foregroundChannel.invokeMethod<List?>(
         GET_ALL_SENT_SMS, args);
 
     return messages
@@ -234,7 +234,7 @@ class Telephony {
     assert(_platform.isAndroid == true, "Can only be called on Android.");
     final args = _getArguments(columns, filter, sortOrder);
 
-    final messages = await _foregroundChannel.invokeMethod<List<LinkedHashMap>>(
+    final messages = await _foregroundChannel.invokeMethod<List?>(
         GET_ALL_DRAFT_SMS, args);
 
     return messages
@@ -262,7 +262,7 @@ class Telephony {
     final args = _getArguments(DEFAULT_CONVERSATION_COLUMNS, filter, sortOrder);
 
     final conversations = await _foregroundChannel
-        .invokeMethod<List<LinkedHashMap>>(GET_ALL_CONVERSATIONS, args);
+        .invokeMethod<List?>(GET_ALL_CONVERSATIONS, args);
 
     return conversations
             ?.map((conversation) => SmsConversation.fromMap(conversation))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: telephony
 description: A Flutter plugin to use telephony features such as fetch network
   info, start phone calls, send and receive SMS, and listen for incoming SMS.
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/shounakmulay/Telephony
 repository: https://github.com/shounakmulay/Telephony
 


### PR DESCRIPTION
Change `invokeMethod` call type from `List<LinkedHashMap<dynamic, dynamic>>?` to `List?` internally.