### PR TITLE
[Changed] List<String> as to in sendSms function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+* Now you can add a list of addresses without using a semi-colon (;) to separate the addresses.
+
+
 ## 0.1.2
 * Change invokeMethod call type for getSms methods to List? (No change to telephony API)
 

--- a/lib/telephony.dart
+++ b/lib/telephony.dart
@@ -294,14 +294,14 @@ class Telephony {
   ///
   /// Parameters:
   ///
-  /// - [to] : Address to send the SMS to.
+  /// - [to] : List of addresses to send the SMS to.
   /// - [message] : Message to be sent. If message body is longer than standard SMS length limits set appropriate
   /// value for [isMultipart]
   /// - [statusListener] (optional) : Listen to the status of the sent SMS. Values can be one of [SmsStatus]
   /// - [isMultipart] (optional) : If message body is longer than standard SMS limit of 160 characters, set this flag to
   /// send the SMS in multiple parts.
   Future<void> sendSms({
-    required String to,
+    required List<String> to,
     required String message,
     SmsSendStatusListener? statusListener,
     bool isMultipart = false,
@@ -328,11 +328,11 @@ class Telephony {
   ///
   /// Parameters:
   ///
-  /// - [to] : Address to send the SMS to.
+  /// - [to] : List of addresses to send the SMS to.
   /// - [message] : Message to be sent.
   ///
   Future<void> sendSmsByDefaultApp({
-    required String to,
+    required List<String> to,
     required String message,
   }) async {
     final Map<String, dynamic> args = {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: telephony
 description: A Flutter plugin to use telephony features such as fetch network
   info, start phone calls, send and receive SMS, and listen for incoming SMS.
-version: 0.1.2
+version: 0.1.3
 homepage: https://github.com/shounakmulay/Telephony
 repository: https://github.com/shounakmulay/Telephony
 

--- a/test/listener_test.dart
+++ b/test/listener_test.dart
@@ -40,7 +40,9 @@ main() {
       };
 
       telephony.sendSms(
-          to: "0000000000", message: "Test message", statusListener: listener);
+          to: ["0000000000"],
+          message: "Test message",
+          statusListener: listener);
 
       expect(log, [isMethodCall(SEND_SMS, arguments: args)]);
 

--- a/test/telephony_test.dart
+++ b/test/telephony_test.dart
@@ -176,7 +176,7 @@ main() {
 
     group("should send", () {
       test("sms", () async {
-        final String address = "0000000000";
+        final List<String> address = ["0000000000"];
         final String body = "Test message";
         when(methodChannel.invokeMethod(SEND_SMS, {
           "address": address,
@@ -200,7 +200,7 @@ main() {
         when(methodChannel.invokeMethod(SEND_MULTIPART_SMS, args))
             .thenAnswer((realInvocation) => Future<void>.value());
         telephony.sendSms(
-            to: "123456", message: "some long message", isMultipart: true);
+            to: ["123456"], message: "some long message", isMultipart: true);
 
         verifyNever(methodChannel.invokeMethod(SEND_SMS, args));
 
@@ -208,7 +208,7 @@ main() {
       });
 
       test("sms by default app", () async {
-        final String address = "123456";
+        final List<String> address = ["123456"];
         final String body = "message";
         when(methodChannel.invokeMethod(
                 SEND_SMS_INTENT, {"address": address, "message_body": body}))


### PR DESCRIPTION
Hi there! 
I hope you are doing fine. I am Ayesha Iftikhar a flutter developer from Pakistan and I have recently used your ```Telephony``  package. Although it is a great package and saves a lot of time and effort for setting up custom platform channels to send or call with minimum user interaction. I find a little issue, in case if the application is saving all the contacts in a list of Strings and it wasn't giving that option to use as receiver address. So, I just made a little effort and change it and it works fine so I thought to share it with others too. I would be delighted if you accept/merge my pull request and allow others to have the benefit from that work too.
Thanks and Regards,
Ayesha Iftikhar
