### PR TITLE
Fix SmsType parsing

### DIFF
--- a/lib/telephony.dart
+++ b/lib/telephony.dart
@@ -632,7 +632,7 @@ class SmsMessage {
           this.threadId = int.tryParse(value);
           break;
         case _SmsProjections.TYPE:
-          this.type = SmsType.values[value];
+          this.type = SmsType.values[int.parse(value)];
           break;
       }
     }

--- a/lib/telephony.dart
+++ b/lib/telephony.dart
@@ -632,7 +632,8 @@ class SmsMessage {
           this.threadId = int.tryParse(value);
           break;
         case _SmsProjections.TYPE:
-          this.type = SmsType.values[int.tryParse(value)];
+          var smsTypeIndex = int.tryParse(value);
+          this.type = smsTypeIndex != null ? SmsType.values[smsTypeIndex] : null;
           break;
       }
     }

--- a/lib/telephony.dart
+++ b/lib/telephony.dart
@@ -632,7 +632,7 @@ class SmsMessage {
           this.threadId = int.tryParse(value);
           break;
         case _SmsProjections.TYPE:
-          this.type = SmsType.values[int.parse(value)];
+          this.type = SmsType.values[int.tryParse(value)];
           break;
       }
     }


### PR DESCRIPTION
Fix https://github.com/shounakmulay/Telephony/issues/86
For parsing in `case _SmsProjections.TYPE` I used `int.parse()` and not `int.tryParse()` so that an exception is thrown if parsing fails, which should never happen if there are no bugs 

I'm not familiar with git so please let me know if I did something wrong with the pull request procedure 