### PR TITLE
Sms failure handling

### DIFF
--- a/android/src/main/kotlin/com/shounakmulay/telephony/sms/SmsMethodCallHandler.kt
+++ b/android/src/main/kotlin/com/shounakmulay/telephony/sms/SmsMethodCallHandler.kt
@@ -34,6 +34,7 @@ import com.shounakmulay.telephony.utils.Constants.SHARED_PREFERENCES_NAME
 import com.shounakmulay.telephony.utils.Constants.SHARED_PREFS_DISABLE_BACKGROUND_EXE
 import com.shounakmulay.telephony.utils.Constants.SMS_BACKGROUND_REQUEST_CODE
 import com.shounakmulay.telephony.utils.Constants.SMS_DELIVERED
+import com.shounakmulay.telephony.utils.Constants.SMS_FAIL
 import com.shounakmulay.telephony.utils.Constants.SMS_QUERY_REQUEST_CODE
 import com.shounakmulay.telephony.utils.Constants.SMS_SEND_REQUEST_CODE
 import com.shounakmulay.telephony.utils.Constants.SMS_SENT
@@ -390,9 +391,21 @@ class SmsMethodCallHandler(
   override fun onReceive(ctx: Context?, intent: Intent?) {
     if (intent != null) {
       when (intent.action) {
-        Constants.ACTION_SMS_SENT -> foregroundChannel.invokeMethod(SMS_SENT, null)
+        Constants.ACTION_SMS_SENT -> {
+          when(resultCode) {
+            Activity.RESULT_OK -> foregroundChannel.invokeMethod(SMS_SENT, null)
+            SmsManager.RESULT_ERROR_GENERIC_FAILURE -> foregroundChannel.invokeMethod(SMS_FAIL, null)
+            SmsManager.RESULT_ERROR_NO_SERVICE -> foregroundChannel.invokeMethod(SMS_FAIL, null)
+            SmsManager.RESULT_ERROR_NULL_PDU -> foregroundChannel.invokeMethod(SMS_FAIL, null)
+            SmsManager.RESULT_ERROR_RADIO_OFF -> foregroundChannel.invokeMethod(SMS_FAIL, null)
+
+          }
+          }
         Constants.ACTION_SMS_DELIVERED -> {
-          foregroundChannel.invokeMethod(SMS_DELIVERED, null)
+          when (resultCode) {
+            Activity.RESULT_OK -> foregroundChannel.invokeMethod(SMS_DELIVERED, null)
+            Activity.RESULT_CANCELED -> foregroundChannel.invokeMethod(SMS_FAIL, null)
+          }
           context.unregisterReceiver(this)
         }
       }

--- a/android/src/main/kotlin/com/shounakmulay/telephony/utils/Constants.kt
+++ b/android/src/main/kotlin/com/shounakmulay/telephony/utils/Constants.kt
@@ -35,7 +35,8 @@ object Constants {
   const val HANDLE_BACKGROUND_MESSAGE = "handleBackgroundMessage"
   const val SMS_SENT = "smsSent"
   const val SMS_DELIVERED = "smsDelivered"
-  
+  const val SMS_FAIL = "smsFail"
+
   // Invoke Method Arguments
   const val HANDLE = "handle"
   const val MESSAGE = "message"

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -35,6 +35,7 @@ const DIAL_PHONE_NUMBER = "dialPhoneNumber";
 const ON_MESSAGE = "onMessage";
 const SMS_SENT = "smsSent";
 const SMS_DELIVERED = "smsDelivered";
+const SMS_FAIL = "smsFail";
 
 ///
 /// Possible parameters that can be fetched during a SMS query operation.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -253,4 +253,4 @@ extension Value on Sort {
 }
 
 /// Represents the status of a sms message sent from the device.
-enum SendStatus { SENT, DELIVERED }
+enum SendStatus { SENT, DELIVERED, FAIL }

--- a/lib/telephony.dart
+++ b/lib/telephony.dart
@@ -149,6 +149,8 @@ class Telephony {
         return _statusListener(SendStatus.SENT);
       case SMS_DELIVERED:
         return _statusListener(SendStatus.DELIVERED);
+      case SMS_FAIL:
+        return _statusListener(SendStatus.FAIL);
     }
   }
 


### PR DESCRIPTION
This fix will handle all sms sending failures (**_`RESULT_ERROR_GENERIC_FAILURE,RESULT_ERROR_NO_SERVICE,RESULT_ERROR_NULL_PDU,RESULT_ERROR_RADIO_OFF`_**) to SMS_FAIL.

For example :
```
final SmsSendStatusListener listener = (SendStatus status) {
	// Handle the status
	switch (status) {
		case SendStatus.SENT:
		  print("SMS is sent!");
		  break;
		case SendStatus.DELIVERED:
		  print("SMS delivered.");
		  break;
		case SendStatus.FAIL:
		  print("Error sending sms");
		  break;
		default:
	  }
};
	
telephony.sendSms(
	to: "1234567890",
	message: "May the force be with you!",
	statusListener: listener
);
```